### PR TITLE
chore: Reduce logger interface to only used methods

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -56,15 +56,7 @@ type SeekInfo struct {
 }
 
 type logger interface {
-	Fatal(v ...interface{})
-	Fatalf(format string, v ...interface{})
-	Fatalln(v ...interface{})
-	Panic(v ...interface{})
-	Panicf(format string, v ...interface{})
-	Panicln(v ...interface{})
-	Print(v ...interface{})
 	Printf(format string, v ...interface{})
-	Println(v ...interface{})
 }
 
 // Config is used to specify how a file must be tailed.


### PR DESCRIPTION
Keep only the methods that are actually used so implementing the interface means only creating a single function.